### PR TITLE
Add snapshots

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -9,7 +9,7 @@ model-paths: ["models"]
 test-paths: ["tests"]
 # seed-paths: ["seeds"]
 macro-paths: ["macros"]
-# snapshot-paths: ["snapshots"]
+snapshot-paths: ["snapshots"]
 
 clean-targets:         # directories to be removed by `dbt clean`
   - "target"
@@ -30,3 +30,8 @@ models:
     purty:
       +materialized: table
       +schema: purty
+
+snapshots:
+  kicking_and_screaming:
+    fact_models:
+      +materialized: snapshot

--- a/models/purty/team_gplus_agg.sql
+++ b/models/purty/team_gplus_agg.sql
@@ -19,7 +19,7 @@ teams.team_id
 , ROW_NUMBER() OVER(PARTITION BY teams.conference, tg.season_name ORDER BY avg_gplus_per_game DESC) AS avg_gplus_conf_rank
 FROM gplus_agg tg
 LEFT JOIN {{ ref('teams_clean') }} teams
-ON tg.team_id = teams.team_id
+	ON tg.team_id = teams.team_id
 LEFT JOIN {{ ref('standings') }} stand
-ON tg.team_id = stand.team_id
-ORDER BY avg_gplus_per_game DESC
+	ON tg.team_id = stand.team_id
+	AND tg.season_name = stand.season_name

--- a/models/purty/team_xg_agg.sql
+++ b/models/purty/team_xg_agg.sql
@@ -3,6 +3,7 @@ xg.team_id
 , teams.team_name
 , teams.conference
 , xg.season_name
+, stand.games_played
 , xg.shots_for
 , xg.shots_against
 , xg.goals_for
@@ -11,13 +12,16 @@ xg.team_id
 , xg.xgoals_for
 , xg.xgoals_against
 , xg.xgoal_difference
-, ROW_NUMBER() OVER(PARTITION BY season_name ORDER BY xgoals_for DESC) AS xgoals_for_rank
-, ROW_NUMBER() OVER(PARTITION BY conference, season_name ORDER BY xgoals_for DESC) AS xgoals_for_conf_rank
-, ROW_NUMBER() OVER(PARTITION BY season_name ORDER BY xgoals_against DESC) AS xgoals_against_rank
-, ROW_NUMBER() OVER(PARTITION BY conference, season_name ORDER BY xgoals_against DESC) AS xgoals_against_conf_rank
-, ROW_NUMBER() OVER(PARTITION BY season_name ORDER BY xgoal_difference DESC) AS xgoal_diff_rank
-, ROW_NUMBER() OVER(PARTITION BY conference, season_name ORDER BY xgoal_difference DESC) AS xgoal_diff_conf_rank
+, ROW_NUMBER() OVER(PARTITION BY xg.season_name ORDER BY xgoals_for DESC) AS xgoals_for_rank
+, ROW_NUMBER() OVER(PARTITION BY teams.conference, xg.season_name ORDER BY xgoals_for DESC) AS xgoals_for_conf_rank
+, ROW_NUMBER() OVER(PARTITION BY xg.season_name ORDER BY xgoals_against DESC) AS xgoals_against_rank
+, ROW_NUMBER() OVER(PARTITION BY teams.conference, xg.season_name ORDER BY xgoals_against DESC) AS xgoals_against_conf_rank
+, ROW_NUMBER() OVER(PARTITION BY xg.season_name ORDER BY xgoal_difference DESC) AS xgoal_diff_rank
+, ROW_NUMBER() OVER(PARTITION BY teams.conference, xg.season_name ORDER BY xgoal_difference DESC) AS xgoal_diff_conf_rank
 FROM {{ source('raw', 'team_xg')  }} xg
 LEFT JOIN {{ ref('teams_clean') }} teams
-ON xg.team_id = teams.team_id
+    ON xg.team_id = teams.team_id
+LEFT JOIN {{ ref('standings') }} stand
+    ON xg.team_id = stand.team_id
+    AND xg.season_name = stand.season_name
 ORDER BY xgoal_difference DESC

--- a/raw_data_etl/schemas_and_starting_scripts/raw_games_tables.py
+++ b/raw_data_etl/schemas_and_starting_scripts/raw_games_tables.py
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS raw.games (
 	attendance HUGEINT,
 	knockout_game BOOLEAN,
 	last_updated_utc TIMESTAMPTZ,
+    extra_time FLOAT,
     penalties FLOAT,
     home_penalties REAL,
     away_penalties REAL

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ duckdb==1.0.*
 itscalledsoccer==1.3.*
 pandas~=2.0
 tqdm==4.65.*
-dbt-duckdb==1.8.*
+dbt-duckdb==1.9.*
 streamlit==1.40.*

--- a/snapshots/fact_models/schema.yml
+++ b/snapshots/fact_models/schema.yml
@@ -1,0 +1,6 @@
+version: 2
+
+snapshots:
+  - name: team_gplus_agg_snapshot
+
+  - name: team_xg_agg_snapshot

--- a/snapshots/fact_models/team_gplus_agg_snapshot.sql
+++ b/snapshots/fact_models/team_gplus_agg_snapshot.sql
@@ -1,0 +1,26 @@
+{% snapshot team_gplus_agg_snapshot %}
+
+    {{
+        config(
+          unique_key="team_id || '-' || season_name",
+          strategy="check",
+          check_cols=['games_played'],
+          target_schema="snapshot"
+        )
+    }}
+
+select
+      team_id
+    , team_name
+    , season_name
+    , conference
+    , games_played
+    , total_gplus
+    , avg_gplus_per_game
+    , team_gplus_rank
+    , team_gplus_conf_rank
+    , avg_gplus_rank
+    , avg_gplus_conf_rank
+from {{ ref("team_gplus_agg") }}
+
+{% endsnapshot %}

--- a/snapshots/fact_models/team_xg_agg_snapshot.sql
+++ b/snapshots/fact_models/team_xg_agg_snapshot.sql
@@ -1,0 +1,29 @@
+{% snapshot team_xg_agg_snapshot %}
+
+    {{
+        config(
+          unique_key="team_id || '-' || season_name",
+          strategy="check",
+          check_cols=['games_played'],
+          target_schema="snapshot"
+        )
+    }}
+
+select
+    team_id
+  , team_name
+  , season_name
+  , conference
+  , games_played
+  , games_played
+  , shots_for
+  , shots_against
+  , goals_for
+  , goals_against
+  , goal_difference
+  , xgoals_for
+  , xgoals_against
+  , xgoal_difference
+from {{ ref("team_xg_agg") }}
+
+{% endsnapshot %}

--- a/snapshots/fact_models/team_xg_agg_snapshot.sql
+++ b/snapshots/fact_models/team_xg_agg_snapshot.sql
@@ -15,7 +15,6 @@ select
   , season_name
   , conference
   , games_played
-  , games_played
   , shots_for
   , shots_against
   , goals_for


### PR DESCRIPTION
This adds 2 snapshots through dbt for gplus and xg aggregated stats. This is for #14 

Fixes a bug when aggregating with season_name (untested for data validation).

Adds a column to extra time for `games`. Also spun up issue #18 as a result.

Bumps dbt-core to 1.9. 
