### PR TITLE
Add gplus and team name to player stats

### DIFF
--- a/models/intermediate/player_gplus.sql
+++ b/models/intermediate/player_gplus.sql
@@ -1,0 +1,18 @@
+SELECT pga.player_id
+, p.player_name
+, pga.team_id
+, t.team_name
+, g.game_id
+, g.matchday
+, pga.* EXCLUDE(player_id, team_id, game_id, data)
+, pga.data.action_type
+, pga.data.goals_added_raw
+, pga.data.goals_added_above_avg
+, pga.data.count_actions
+FROM {{ source('raw', 'player_goals_added') }} pga
+LEFT JOIN {{ source('raw', 'players') }} p
+ON pga.player_id = p.player_id
+LEFT JOIN {{ source('raw', 'teams') }} t
+ON pga.team_id = t.team_id
+LEFT JOIN {{ source('raw', 'games') }} g
+ON pga.game_id = g.game_id

--- a/models/intermediate/player_xg.sql
+++ b/models/intermediate/player_xg.sql
@@ -1,6 +1,8 @@
 SELECT xg.player_id
 , p.player_name
 , xg.season_name
+, xg.team_id
+, t.team_name
 , xg.game_id
 , g.matchday
 , xg.general_position
@@ -12,6 +14,8 @@ SELECT xg.player_id
 , xg.goals_minus_xgoals
 FROM {{ source('raw', 'player_xg') }} xg
 LEFT JOIN {{ source('raw', 'players') }} p
-ON xg.player_id = p.player_id 
+ON xg.player_id = p.player_id
+LEFT JOIN {{ source('raw', 'teams') }} t
+ON xg.team_id = t.team_id
 LEFT JOIN {{ source('raw', 'games') }} g
 ON xg.game_id = g.game_id

--- a/models/intermediate/schema.yml
+++ b/models/intermediate/schema.yml
@@ -29,4 +29,9 @@ models:
           - not_null
 
   - name: player_xg
-    description: "Player xg with game matchday and player name"
+    description: "Player xg with game matchday, player name, and team name"
+
+  - name: player_gplus
+    description: "Player gplus with game matchday, player name, and team name"
+
+    

--- a/models/purty/player_gplus_agg.sql
+++ b/models/purty/player_gplus_agg.sql
@@ -1,0 +1,20 @@
+with player_gplus_agg AS (
+	SELECT player_id
+	, player_name
+	, team_id
+	, team_name
+	, season_name
+	, general_position
+	, minutes_played
+	, action_type
+	, SUM(goals_added_raw) OVER(PARTITION BY player_id, season_name) AS total_gplus
+	, SUM(goals_added_raw) OVER(PARTITION BY player_id, season_name, action_type) AS gplus_action_type
+	FROM {{ ref('player_gplus') }}
+	QUALIFY 1 = ROW_NUMBER() OVER(PARTITION BY player_id, season_name, action_type)
+) SELECT *
+, DENSE_RANK() OVER(PARTITION BY season_name ORDER BY total_gplus DESC)  AS gplus_league_rank
+, DENSE_RANK() OVER(PARTITION BY season_name, action_type ORDER BY gplus_action_type DESC)  AS gplus_league_action_rank
+, DENSE_RANK() OVER(PARTITION BY team_id, season_name ORDER BY total_gplus DESC)  AS gplus_team_rank
+, DENSE_RANK() OVER(PARTITION BY team_id, season_name, action_type ORDER BY gplus_action_type DESC)  AS gplus_team_action_rank
+FROM player_gplus_agg
+ORDER BY gplus_league_rank

--- a/models/purty/player_stats_agg.sql
+++ b/models/purty/player_stats_agg.sql
@@ -1,0 +1,28 @@
+with gplus_agg AS (
+	SELECT player_id
+	, player_name
+	, team_id
+	, team_name
+	, season_name
+	, total_gplus
+	, gplus_league_rank
+	FROM {{ ref('player_gplus_agg') }}
+	QUALIFY 1 = ROW_NUMBER() OVER(PARTITION BY player_id, season_name)
+) 
+SELECT xg.player_id
+, xg.player_name
+, gp.team_id
+, gp.team_name
+, xg.season_name
+, gp.total_gplus
+, gp.gplus_league_rank
+, xg.total_goals
+, xg.total_xg
+, xg.rolling_three_game_xgsum
+, xg.rolling_five_game_xgsum
+, xg.rolling_three_game_xgavg
+, xg.rolling_five_game_xgavg
+FROM {{ ref('player_xg_current_agg') }} xg
+JOIN gplus_agg gp
+ON xg.player_id = gp.player_id
+AND xg.season_name = gp.season_name

--- a/models/purty/player_xg_current_agg.sql
+++ b/models/purty/player_xg_current_agg.sql
@@ -1,3 +1,13 @@
-SELECT *
+SELECT player_id
+, player_name
+, matchday
+, season_name
+, general_position
+, SUM(goals) OVER(PARTITION BY player_id, season_name) AS total_goals
+, SUM(xgoals) OVER(PARTITION BY player_id, season_name) AS total_xg
+, rolling_three_game_xgsum
+, rolling_five_game_xgsum
+, rolling_three_game_xgavg
+, rolling_five_game_xgavg
 FROM {{ ref('player_xg_agg') }}
-QUALIFY 1 = ROW_NUMBER() OVER(PARTITION BY player_id ORDER BY season_name DESC, matchday DESC)
+QUALIFY 1 = ROW_NUMBER() OVER(PARTITION BY player_id, season_name ORDER BY matchday DESC)

--- a/models/purty/schema.yml
+++ b/models/purty/schema.yml
@@ -122,3 +122,21 @@ models:
       - name: player_id
         data_tests:
           - not_null
+
+  - name: player_gplus_agg
+    description: "Player gplus data. Unique per player, season, AND action type"
+    columns:
+      - name: player_id
+        data_tests:
+          - not_null
+      
+      - name: total_gplus
+        data_tests:
+          - not_null
+
+  - name: player_stats_agg
+    description: "Gplus and XG data for each player"
+    columns:
+      - name: player_id
+        data_tests:
+          - not_null

--- a/models/raw/sources.yml
+++ b/models/raw/sources.yml
@@ -84,3 +84,7 @@ sources:
 
       - name: player_xg
         description: "One record per game and player_id"
+
+      - name: player_goals_added
+        description: "Player goals added for each game (6 action types per game)"
+        

--- a/tests/assert_player_ga_correct_action_types_inter.sql
+++ b/tests/assert_player_ga_correct_action_types_inter.sql
@@ -1,0 +1,6 @@
+SELECT 
+  player_id
+, game_id, COUNT(DISTINCT action_type)
+FROM {{ ref('player_gplus') }}
+GROUP BY 1,2 
+HAVING COUNT(DISTINCT action_type) != 6

--- a/tests/assert_player_ga_correct_action_types_inter.sql
+++ b/tests/assert_player_ga_correct_action_types_inter.sql
@@ -1,6 +1,7 @@
 SELECT 
   player_id
-, game_id, COUNT(DISTINCT action_type)
+, game_id
+, COUNT(DISTINCT action_type)
 FROM {{ ref('player_gplus') }}
 GROUP BY 1,2 
 HAVING COUNT(DISTINCT action_type) != 6

--- a/tests/assert_player_ga_correct_action_types_raw.sql
+++ b/tests/assert_player_ga_correct_action_types_raw.sql
@@ -1,6 +1,7 @@
 SELECT 
   player_id
-, game_id, COUNT(DISTINCT data.action_type)
+, game_id
+, COUNT(DISTINCT data.action_type)
 FROM {{ source('raw', 'player_goals_added') }}
 GROUP BY 1,2 
 HAVING COUNT(DISTINCT data.action_type) != 6

--- a/tests/assert_player_ga_correct_action_types_raw.sql
+++ b/tests/assert_player_ga_correct_action_types_raw.sql
@@ -1,0 +1,6 @@
+SELECT 
+  player_id
+, game_id, COUNT(DISTINCT data.action_type)
+FROM {{ source('raw', 'player_goals_added') }}
+GROUP BY 1,2 
+HAVING COUNT(DISTINCT data.action_type) != 6

--- a/tests/assert_player_xg_unique_sur_key_int.sql
+++ b/tests/assert_player_xg_unique_sur_key_int.sql
@@ -1,0 +1,7 @@
+SELECT 
+  player_id
+, game_id
+, COUNT(*)
+FROM {{ ref('player_xg') }} --test intermediate model
+GROUP BY 1,2 
+HAVING COUNT(*) > 1

--- a/tests/assert_player_xg_unique_sur_key_int_raw.sql
+++ b/tests/assert_player_xg_unique_sur_key_int_raw.sql
@@ -1,0 +1,7 @@
+SELECT 
+  player_id
+, game_id
+, COUNT(*)
+FROM {{ source('raw', 'player_xg') }}
+GROUP BY 1,2 
+HAVING COUNT(*) > 1

--- a/tests/assert_purty_player_stats_unique_season_stats.sql
+++ b/tests/assert_purty_player_stats_unique_season_stats.sql
@@ -1,0 +1,7 @@
+SELECT 
+  player_id
+, season_name
+, COUNT(*) AS total_records
+FROM {{ ref('player_stats_agg') }}
+GROUP BY 1, 2 
+HAVING COUNT(*) > 1


### PR DESCRIPTION
This creates a more holistic player view by creating and combining gplus with xg data. Also allows users to filter players by a specific team, allowing for analysis like "In the matchup of xxx and yyy, how do these two players compare?" Both at the position and in individual battles (like a LB vs a winger).

Also adds more tests to these specific builds.